### PR TITLE
Avoiding UnicodeEncodeError exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+__pycache__/

--- a/pyramid_xml_renderer/serializer.py
+++ b/pyramid_xml_renderer/serializer.py
@@ -6,7 +6,7 @@ def _convert_to_xml_recurse(parent, data, adapters={}):
     """helper function for converting given data var to xml"""
     #Iterating through a dict and creating parts of xml like <key></key>
     if isinstance(data, dict):
-        for (tag, child) in sorted(data.iteritems()):
+        for (tag, child) in sorted(data.items()):
             if isinstance(child, list) or isinstance(child, tuple):
                 #Creating xml element from dict key
                 listelem = ET.Element(tag)
@@ -101,7 +101,7 @@ def dumps(data, renderers={}):
 
     root = ET.Element('data')
     _convert_to_xml_recurse(root, data, renderers)
-    return "<?xml version='1.0' encoding='utf-8'?>" + ET.tostring(root)
+    return "<?xml version='1.0' encoding='utf-8'?>" + ET.tostring(root, encoding='utf8', method='xml')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When parsing unicode objects with accents, it raises an UnicodeEncodeError error:

``` python
>>> unicode_obj = u'Amapá'
>>> import xml.etree.cElementTree as ET
>>> el = ET.Element(unicode_obj)
>>> ET.tostring(el)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 1126, in tostring
    ElementTree(element).write(file, encoding, method=method)
  File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 817, in write
    self._root, encoding, default_namespace
  File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 884, in _namespaces
    add_qname(tag)
  File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 868, in add_qname
    qnames[qname] = encode(qname)
  File "/usr/lib/python2.7/xml/etree/ElementTree.py", line 843, in encode
    return text.encode(encoding)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe1' in position 4: ordinal not in range(128)
>>> ET.tostring(el, encoding='utf-8', method='xml')
'<Amap\xc3\xa1 />'
>>> 
```
